### PR TITLE
Fix crash caused by CGeneral::GetRandomNumberInRange

### DIFF
--- a/source/game_sa/Audio/CAEAudioUtility.cpp
+++ b/source/game_sa/Audio/CAEAudioUtility.cpp
@@ -25,8 +25,8 @@ void CAEAudioUtility::InjectHooks()
 // 0x4d9c10
 std::int32_t CAEAudioUtility::GetRandomNumberInRange(std::int32_t min, std::int32_t max)
 {
-    // This and CGeneral differs in that this function returns a number [min, max], while
-    // the other [min, max). To solve this we do `max + 1`
+    // This and CGeneral differs in that this function returns a number [min, max + 1], while
+    // the other [min, max]. To solve this we do `max + 1`
     return CGeneral::GetRandomNumberInRange(min, max + 1);
 }
 

--- a/source/game_sa/Audio/CAEAudioUtility.cpp
+++ b/source/game_sa/Audio/CAEAudioUtility.cpp
@@ -25,7 +25,9 @@ void CAEAudioUtility::InjectHooks()
 // 0x4d9c10
 std::int32_t CAEAudioUtility::GetRandomNumberInRange(std::int32_t min, std::int32_t max)
 {
-    return min + static_cast<int>(rand() * RAND_MAX_RECIPROCAL * (max - min + 1));
+    // This and CGeneral differs in that this function returns a number [min, max], while
+    // the other [min, max). To solve this we do `max + 1`
+    return CGeneral::GetRandomNumberInRange(min, max + 1);
 }
 
 // 0x4d9c50

--- a/source/game_sa/Audio/CAEAudioUtility.cpp
+++ b/source/game_sa/Audio/CAEAudioUtility.cpp
@@ -23,9 +23,9 @@ void CAEAudioUtility::InjectHooks()
 }
 
 // 0x4d9c10
-std::int32_t CAEAudioUtility::GetRandomNumberInRange(std::int32_t a, std::int32_t b)
+std::int32_t CAEAudioUtility::GetRandomNumberInRange(std::int32_t min, std::int32_t max)
 {
-    return CGeneral::GetRandomNumberInRange(a, b);
+    return min + static_cast<int>(rand() * RAND_MAX_RECIPROCAL * (max - min + 1));
 }
 
 // 0x4d9c50

--- a/source/game_sa/CGeneral.cpp
+++ b/source/game_sa/CGeneral.cpp
@@ -135,9 +135,11 @@ float CGeneral::GetAngleBetweenPoints(float x1, float y1, float x2, float y2) {
 }
 
 // 0x407180
+// Differs from CAEAudioUtility in that this one returns [min, max), while
+// the other one returns [mim, max]
 unsigned int CGeneral::GetRandomNumberInRange(int min, int max) {
     // TODO: Use better RNG
-    return min + static_cast<int>(rand() * RAND_MAX_RECIPROCAL * (max - min + 1) );
+    return min + static_cast<int>(rand() * RAND_MAX_RECIPROCAL * (max - min));
 }
 
 // 0x41BD90


### PR DESCRIPTION
Originally it never returned `max`